### PR TITLE
Add payment method selector to profile edit

### DIFF
--- a/src/app/profile/page.tsx
+++ b/src/app/profile/page.tsx
@@ -12,6 +12,7 @@ interface Profile {
   username: string;
   email?: string;
   balance?: number;
+  payment_method?: string;
   payment_id?: string;
   enable_email_notifications?: boolean;
 }
@@ -29,6 +30,7 @@ export default function UserProfile() {
   const [user, setUser] = useState<User | null>(null);
   const [profile, setProfile] = useState<Profile | null>(null);
   const [newUsername, setNewUsername] = useState<string>("");
+  const [paymentMethod, setPaymentMethod] = useState<string>("");
   const [paymentId, setPaymentId] = useState<string>("");
   const [loading, setLoading] = useState<boolean>(false);
   const [isModalOpen, setIsModalOpen] = useState<boolean>(false);
@@ -56,7 +58,7 @@ export default function UserProfile() {
 
       const { data: profileData, error: profileError } = await supabase
         .from("profiles")
-        .select("id, username, email, balance, payment_id, enable_email_notifications")
+        .select("id, username, email, balance, payment_method, payment_id, enable_email_notifications")
         .eq("user_id", userData.user.id)
         .single();
 
@@ -227,6 +229,7 @@ export default function UserProfile() {
   const openEditModal = () => {
     if (!profile) return;
     setNewUsername(profile.username || "");
+    setPaymentMethod(profile.payment_method || "PayPal");
     setPaymentId(profile.payment_id || "");
     setIsModalOpen(true);
   };
@@ -234,6 +237,7 @@ export default function UserProfile() {
   const closeEditModal = () => {
     setIsModalOpen(false);
     setNewUsername("");
+    setPaymentMethod("");
     setPaymentId("");
   };
 
@@ -243,8 +247,9 @@ export default function UserProfile() {
 
     const { error: updateError } = await supabase
       .from("profiles")
-      .update({ 
+      .update({
         username: newUsername,
+        payment_method: paymentMethod,
         payment_id: paymentId
       })
       .eq("id", profile.id);
@@ -252,10 +257,11 @@ export default function UserProfile() {
     if (updateError) {
       console.error("Error updating profile:", updateError.message);
     } else {
-      setProfile({ 
-        ...profile, 
+      setProfile({
+        ...profile,
         username: newUsername,
-        payment_id: paymentId 
+        payment_method: paymentMethod,
+        payment_id: paymentId
       });
       closeEditModal();
     }
@@ -438,7 +444,13 @@ export default function UserProfile() {
                 <p className="text-white">{formatCurrency(profile.balance || 0)}</p>
               </div>
               <div>
-                <p className="text-gray-400">Payment ID</p>
+                <p className="text-gray-400">Payment Method</p>
+                <p className="text-white">{profile.payment_method || 'Not set'}</p>
+              </div>
+              <div>
+                <p className="text-gray-400">
+                  {profile.payment_method === 'MTurk' ? 'MTurk Worker ID' : 'PayPal Email'}
+                </p>
                 <p className="text-white">{profile.payment_id || 'N/A'}</p>
               </div>
             </div>
@@ -493,6 +505,8 @@ export default function UserProfile() {
         <EditProfileModal
           newUsername={newUsername}
           setNewUsername={setNewUsername}
+          paymentMethod={paymentMethod}
+          setPaymentMethod={setPaymentMethod}
           paymentId={paymentId}
           setPaymentId={setPaymentId}
           onClose={closeEditModal}

--- a/src/components/EditProfileModal.tsx
+++ b/src/components/EditProfileModal.tsx
@@ -5,6 +5,8 @@ import React from "react";
 interface EditProfileModalProps {
   newUsername: string;
   setNewUsername: (value: string) => void;
+  paymentMethod: string;
+  setPaymentMethod: (value: string) => void;
   paymentId: string;
   setPaymentId: (value: string) => void;
   onClose: () => void;
@@ -15,12 +17,15 @@ interface EditProfileModalProps {
 export default function EditProfileModal({
   newUsername,
   setNewUsername,
+  paymentMethod,
+  setPaymentMethod,
   paymentId,
   setPaymentId,
   onClose,
   onSave,
   loading,
 }: EditProfileModalProps) {
+  const isMTurk = paymentMethod === "MTurk";
   return (
     <div className="fixed inset-0 flex items-center justify-center bg-black bg-opacity-50 z-50">
       <div className="bg-gray-800 p-6 rounded-lg w-full max-w-md">
@@ -39,14 +44,39 @@ export default function EditProfileModal({
           </div>
           
           <div>
-            <label className="block text-white text-sm font-medium mb-2">Payment ID</label>
+            <label className="block text-white text-sm font-medium mb-2">Payment Method</label>
+            <select
+              value={paymentMethod}
+              onChange={(e) => setPaymentMethod(e.target.value)}
+              className="text-black p-2 rounded w-full"
+            >
+              <option value="PayPal">PayPal</option>
+              <option value="MTurk">MTurk</option>
+            </select>
+            <p className="text-gray-400 text-xs mt-1">
+              MTurk payouts are being discontinued — switch to PayPal to keep
+              receiving your payments.
+            </p>
+          </div>
+
+          <div>
+            <label className="block text-white text-sm font-medium mb-2">
+              {isMTurk ? "MTurk Worker ID" : "PayPal Email"}
+            </label>
             <input
               type="text"
               value={paymentId}
               onChange={(e) => setPaymentId(e.target.value)}
               className="text-black p-2 rounded w-full"
-              placeholder="Enter payment ID (PayPal/MTurk)"
+              placeholder={
+                isMTurk ? "Enter your MTurk Worker ID" : "Enter your PayPal email address"
+              }
             />
+            <p className="text-gray-400 text-xs mt-1">
+              {isMTurk
+                ? "This is where your MTurk bonus payouts are sent."
+                : "This is the PayPal account your payouts will be sent to — make sure it matches your PayPal login email."}
+            </p>
           </div>
         </div>
         


### PR DESCRIPTION
## Problem

A user (paid via MTurk) reported confusion: their profile shows a **Payment ID** (their MTurk ID) but no payment method, and the migration email told them to switch to PayPal. They asked whether to just replace the MTurk ID with their PayPal ID.

They were right to be confused — and doing so wasn't actually enough. The profile edit form only ever wrote `payment_id`, never `payment_method`. So a user who swapped in their PayPal email stayed flagged as `MTurk` in the DB. The admin Send Payments page routes **by `payment_method`**, so these users were sent down the MTurk rail (`send-mturk-bonus` with a PayPal email as the worker ID → fails) or filtered out of payouts entirely when the method was null. The MTurk→PayPal migration was effectively impossible through the UI.

## Fix

- Add a **Payment Method** dropdown (PayPal / MTurk) to `EditProfileModal`, with method-aware labels/placeholders/helper text ("PayPal Email" vs "MTurk Worker ID") so it's clear what to enter and where.
- Thread `payment_method` through the profile page: fetch it, seed edit state (defaulting to PayPal), write it on save, and display it read-only on the profile card.

`payment_method` already exists on the production `profiles` table, so no schema change is needed for this.

## Related

A companion data-reconciliation migration in the admin repo backfills `payment_method = 'PayPal'` for users who already swapped in a PayPal email before this fix.

## Verification

`npm run build` compiles and type-checks clean (the `/analytics` prerender error in a bare checkout is a pre-existing missing-env-var issue, unrelated to this change).

🤖 Generated with [Claude Code](https://claude.com/claude-code)