### PR TITLE
Show PayPal reminder banner in the main app for users without PayPal

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,6 +1,7 @@
 import type { Metadata } from "next";
 import "./globals.css";
 import Navbar from "@/components/navbar";
+import MigrationBanner from "@/components/MigrationBanner";
 
 export const metadata: Metadata = {
   title: "Prediction market",
@@ -15,6 +16,7 @@ export default function RootLayout({
   return (
     <html lang="en">
       <body className="bg-[#101827] min-h-screen w-full">
+        <MigrationBanner/>
         <Navbar/>
         {children}
       </body>

--- a/src/components/MigrationBanner.tsx
+++ b/src/components/MigrationBanner.tsx
@@ -1,0 +1,82 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import supabase from "@/lib/supabase/createClient";
+import Link from "next/link";
+
+// Nudge shown to logged-in players who don't have PayPal set as their payout
+// method. Covers two cases: users still on MTurk (which is being retired) and
+// users who never provided any payment info at all. Both are un-payable until
+// they add PayPal on the profile page.
+export default function MigrationBanner() {
+  const [needsPayPal, setNeedsPayPal] = useState(false);
+  const [isMTurk, setIsMTurk] = useState(false);
+  const [dismissed, setDismissed] = useState(false);
+
+  useEffect(() => {
+    const checkPaymentMethod = async () => {
+      const {
+        data: { user },
+      } = await supabase.auth.getUser();
+      if (!user) {
+        setNeedsPayPal(false);
+        return;
+      }
+
+      // profiles.id is a bigint, so the auth user must be matched on user_id.
+      const { data, error } = await supabase
+        .from("profiles")
+        .select("payment_method")
+        .eq("user_id", user.id)
+        .maybeSingle();
+
+      if (error || !data) return;
+
+      const method = (data.payment_method || "").trim();
+      if (method !== "PayPal") {
+        setNeedsPayPal(true);
+        setIsMTurk(method === "MTurk");
+      } else {
+        setNeedsPayPal(false);
+      }
+    };
+
+    checkPaymentMethod();
+
+    // Re-check on login/logout so the banner appears right after sign-in.
+    const { data: authListener } = supabase.auth.onAuthStateChange(() => {
+      checkPaymentMethod();
+    });
+
+    return () => {
+      authListener?.subscription?.unsubscribe();
+    };
+  }, []);
+
+  if (!needsPayPal || dismissed) return null;
+
+  return (
+    <div className="w-full bg-amber-500 text-black px-4 py-3 flex items-center justify-between gap-4">
+      <p className="text-sm font-medium">
+        {isMTurk
+          ? "⚠️ You're set up to receive payouts via MTurk, which is being discontinued. Add your PayPal info so you don't miss future payouts."
+          : "⚠️ We don't have your PayPal info on file. Add it so you can receive your payouts."}
+      </p>
+      <div className="flex items-center gap-2 shrink-0">
+        <Link
+          href="/profile"
+          className="px-3 py-1.5 bg-black text-white rounded-md text-sm font-semibold hover:bg-gray-800 whitespace-nowrap"
+        >
+          Add PayPal
+        </Link>
+        <button
+          onClick={() => setDismissed(true)}
+          aria-label="Dismiss"
+          className="px-2 text-black/70 hover:text-black text-xl leading-none"
+        >
+          ×
+        </button>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## Problem

New users are never asked for payment info — signup is just email + password, there's no onboarding step, and the `Onboarding` component that would collect PayPal/MTurk info is dead code (never routed). So a user can sign up, trade, and accrue a balance while remaining **un-payable**, with nothing prompting them to add payout info.

The one reminder that existed — `MigrationBanner` — didn't help:
1. It was rendered only in the **admin app's** navbar, so regular players never saw it.
2. It fired only when `payment_method === 'MTurk'`, so users with **no payment method on file** got nothing.

(Concrete case: an active user who signed up and traded the same day sits with `payment_method = null` and no way to be paid, never having been prompted.)

## Change

Add a `MigrationBanner` to the **main app** layout (above the navbar, site-wide) that shows for any logged-in user whose `payment_method` isn't `PayPal`:
- **No method on file** → "We don't have your PayPal info on file. Add it so you can receive your payouts."
- **Still on MTurk** → "MTurk is being discontinued. Add your PayPal info so you don't miss future payouts."

Both link to the profile edit page (where the newly-added payment-method selector lets them set PayPal). Dismissible, and re-checks on auth state change so it appears right after sign-in.

## Notes / follow-ups (not in this PR)

- The deeper gap is that payment collection is entirely optional and un-prompted — wiring `Onboarding` (or a required payment step) into post-signup is the more complete fix. Flagging for a separate change.
- There's still **no email reminder** anywhere in the codebase; `enable_email_notifications` is stored but never acted on. The migration email users received came from an external/manual process.

## Verification

`npm run build` compiles and type-checks clean (the `/analytics` prerender error in a bare checkout is a pre-existing missing-env-var issue, unrelated to this change).

🤖 Generated with [Claude Code](https://claude.com/claude-code)